### PR TITLE
Added an additional check for existing cache item

### DIFF
--- a/wheels/cache/storage/Memory.cfc
+++ b/wheels/cache/storage/Memory.cfc
@@ -26,7 +26,7 @@
 			var loc = {};
 			loc.value = false;
 			
-			if (StructKeyExists(variables.$instance.cache, arguments.key))
+			if (StructKeyExists(variables.$instance.cache, arguments.key) && IsDefined("variables.$instance.cache[#arguments.key#]"))
 			{
 				if (IsSimpleValue(variables.$instance.cache[arguments.key]))
 				{


### PR DESCRIPTION
For some reason the changes to the ExpiresAt function have a knock on affect, and cause an error here. I have added an extra check as the StructKeyExists doesn't seem to work. This seems to work for me, but may need adjusting.
